### PR TITLE
qa/v2.5 -> v2.5.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,9 @@ build-%:
 stop-all:
 	docker-compose down;
 
-	cd lib/gohan && \
+	cd lib/bento_public && \
+	docker-compose down && \
+	cd ../gohan && \
 	docker-compose down && \
 	cd ../.. ;
 

--- a/etc/bento.env
+++ b/etc/bento.env
@@ -346,4 +346,4 @@ GOHAN_TAG=v3.4.0
 # Bento-Public
 BENTO_PUBLIC_REPO=https://github.com/bento-platform/bento_public
 BENTO_PUBLIC_BRANCH=main
-BENTO_PUBLIC_TAG=v0.2.0
+BENTO_PUBLIC_TAG=v0.3.0

--- a/etc/bento.env
+++ b/etc/bento.env
@@ -141,7 +141,7 @@ BENTOV2_SERVICE_REGISTRY_CPUS=1
 # Katsu
 KATSU_REPO=https://github.com/bento-platform/katsu
 KATSU_BRANCH=develop
-KATSU_TAG=v2.8.0
+KATSU_TAG=v2.9.0
 BENTOV2_KATSU_BASE_IMAGE=bentov2-common-alpine-python
 BENTOV2_KATSU_BASE_IMAGE_VERSION=0.0.1
 BENTOV2_KATSU_IMAGE=bentov2-katsu


### PR DESCRIPTION
- bump katsu and bento_public versions
- makefile patch