### PR TITLE
Fix gateway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,18 +277,18 @@ run-%:
 		envsubst < ./lib/gateway/nginx.conf.tpl > ./lib/gateway/nginx.conf.pre; \
 		if [[ ${BENTOV2_USE_EXTERNAL_IDP} == 1 ]]; then \
 			echo "Fine tuning nginx.conf to use an External IDP"; \
-			sed -i '/-- Internal IDP Starts Here --/,/-- Internal IDP Ends Here --/d' ./lib/gateway/nginx.conf.pre; \
+			sed -i '' '/-- Internal IDP Starts Here --/,/-- Internal IDP Ends Here --/d' ./lib/gateway/nginx.conf.pre; \
 		else \
 			echo "Fine tuning nginx.conf to use an Internal IDP"; \
 		fi && \
 		if [[ ${BENTOV2_USE_BENTO_PUBLIC} == 1 ]]; then \
 			echo "Fine tuning nginx.conf to use Bento-Public"; \
 			\
-			sed -i '/-- Do Not Use Bento-Public Starts Here --/,/-- Do Not Use Bento-Public Ends Here --/d' ./lib/gateway/nginx.conf.pre; \
+			sed -i '' '/-- Do Not Use Bento-Public Starts Here --/,/-- Do Not Use Bento-Public Ends Here --/d' ./lib/gateway/nginx.conf.pre; \
 		else \
 			echo "Fine tuning nginx.conf to disable Bento-Public"; \
 			\
-			sed -i '/-- Use Bento-Public Starts Here --/,/-- Use Bento-Public Ends Here --/d' ./lib/gateway/nginx.conf.pre; \
+			sed -i '' '/-- Use Bento-Public Starts Here --/,/-- Use Bento-Public Ends Here --/d' ./lib/gateway/nginx.conf.pre; \
 			\
 		fi && \
 		cat ./lib/gateway/nginx.conf.pre > ./lib/gateway/nginx.conf; \

--- a/Makefile
+++ b/Makefile
@@ -423,20 +423,20 @@ clean-%:
 	@# Clean public using native makefile
 	@if [[ $* == public ]]; then \
 		cd lib/bento_public && $(MAKE) clean-public ; \
-	fi &>> tmp/logs/${EXECUTED_NOW}/$*/clean.log
+	fi >> tmp/logs/${EXECUTED_NOW}/$*/clean.log 2>&1
 
 	@# Clean gohan using native makefile
 	@if [[ $* == gohan ]]; then \
 		cd lib/gohan &&  \
 		$(MAKE) clean-api ; \
-	fi &>> tmp/logs/${EXECUTED_NOW}/$*/clean.log
+	fi >> tmp/logs/${EXECUTED_NOW}/$*/clean.log 2>&1
 
 
 	@# Skip triggering top level makefile stop for both public and gohan
 	@if [[ $* != public && $* != gohan ]]; then \
 		echo "-- Stopping $* --" ; \
 		docker-compose stop $* &> tmp/logs/${EXECUTED_NOW}/$*/clean.log ; \
-	fi &>> tmp/logs/${EXECUTED_NOW}/$*/clean.log
+	fi >> tmp/logs/${EXECUTED_NOW}/$*/clean.log 2>&1
 
 
 	@# Some services don't need their images removed

--- a/lib/web/dev_startup.sh
+++ b/lib/web/dev_startup.sh
@@ -4,8 +4,10 @@ cd bento_web;
 chown -R $BENTO_WEB_USER dist
 chgrp -R $BENTO_WEB_USER dist
 
-echo "-- Running `npm run watch`.. --";
-npm run watch &
+echo "-- Toggling nginx daemon : off --"
+nginx -g 'daemon off;' &
 
-echo "-- Toggling nginx daemon : off --";
-nginx -g 'daemon off;'
+# Removing the ampersand from the following line will prevent webpack output
+# to be streamed to stdout
+echo "-- Running `npm run watch`.. --" &
+npm run watch


### PR DESCRIPTION
This branch fixes 2 issues with the makefile on MacOS:
- gateway: `sed -i` expects a suffix on MacOS
- clean-*: unsupported stream redirection syntax `&>>`

Also, improvements wrt starting bento-web in dev mode: fix "wrong gateway" issue and allow to stream webpack output to the docker container logs.