### PR TITLE
better tag/branch cloning

### DIFF
--- a/lib/drop-box/Dockerfile
+++ b/lib/drop-box/Dockerfile
@@ -13,12 +13,9 @@ ARG REPO
 ARG BRANCH
 ARG TAG
 
-RUN git clone "${REPO}" && \
+RUN git clone --depth 1 -b "${TAG:-$BRANCH}" "${REPO}" && \
     ls /drop-box;
 WORKDIR /drop-box/bento_drop_box_service
-RUN git fetch && \
-    git checkout "${BRANCH}" &&  \
-    git checkout tags/${TAG}
 
 RUN pip install -r requirements.txt
 

--- a/lib/drs/Dockerfile
+++ b/lib/drs/Dockerfile
@@ -15,18 +15,13 @@ ARG REPO
 ARG BRANCH
 ARG TAG
 
-RUN git clone "${REPO}" && \
+RUN git clone --depth 1 -b "${TAG:-$BRANCH}" "${REPO}" && \
     ls /drs
 
 WORKDIR /drs/bento_drs
 
-RUN git fetch && \
-    git checkout "${BRANCH}" &&  \
-    git checkout tags/${TAG} && \
-    \
-    mkdir -p /drs/bento_drs/data/obj && \
+RUN mkdir -p /drs/bento_drs/data/obj && \
     mkdir -p /drs/bento_drs/data/db;
-#     git pull $(echo "${REPO} refs/tags/${TAG}:refs/tags/${TAG}") && \
 
 # Remove comment if custom requirements are needed
 #COPY requirements.txt ./requirements.txt

--- a/lib/event-relay/Dockerfile
+++ b/lib/event-relay/Dockerfile
@@ -19,15 +19,12 @@ ARG REPO
 ARG BRANCH
 ARG TAG
 
-RUN git clone "${REPO}"
+# Clone the repo
+RUN git clone --depth 1 -b "${TAG:-$BRANCH}" "${REPO}"
 
 WORKDIR /event-relay/bento_event_relay
-RUN git fetch && \
-    git checkout "${BRANCH}" && \
-    git checkout tags/${TAG}
 
 RUN ["npm", "install"]
 
 # Run
-WORKDIR /event-relay/bento_event_relay
 CMD ["npm", "start"]

--- a/lib/federation/Dockerfile
+++ b/lib/federation/Dockerfile
@@ -17,12 +17,10 @@ ARG REPO
 ARG BRANCH
 ARG TAG
 
-RUN git clone "${REPO}" && \
+RUN git clone --depth 1 -b "${TAG:-$BRANCH}" "${REPO}" && \
     ls /federation
 WORKDIR /federation/bento_federation_service
-RUN git fetch && \
-    git checkout "${BRANCH}" && \
-    git checkout tags/${TAG}
+
 RUN ["pip", "install", "-r", "requirements.txt"]
 
 # Run

--- a/lib/katsu/Dockerfile
+++ b/lib/katsu/Dockerfile
@@ -23,15 +23,12 @@ ARG KATSU_TAG
 ARG PROJECT_DIRECTORY
 
 # Clone the repo
-RUN git clone "${KATSU_REPO}"
+RUN git clone --depth 1 -b "${KATSU_TAG:-$KATSU_BRANCH}" "${KATSU_REPO}"
 
 WORKDIR ${PROJECT_DIRECTORY}
 
 RUN git config user.name "docker" && \
     git config user.email "docker@bento.v2" && \
-    git fetch && \
-    git checkout "${KATSU_BRANCH}" && \
-    git checkout tags/${KATSU_TAG} && \
     git submodule update --init
 
 
@@ -42,7 +39,7 @@ RUN ["sed", "-i", "15s/.*/cryptography==2.8/", "requirements.txt"]
 RUN pip install -r requirements.txt;
 
 
-# TEMP: modify settings.py file to allow for 
+# TEMP: modify settings.py file to allow for
 # localhost+port & domain host name to be allowed to make calls
 ARG BENTOV2_PORTAL_DOMAIN
 RUN sed -i "s/CHORD_HOST = urlparse(CHORD_URL or \"\").netloc/CHORD_HOST = \"${BENTOV2_PORTAL_DOMAIN}\"/" ${PROJECT_DIRECTORY}/chord_metadata_service/metadata/settings.py

--- a/lib/logging/Dockerfile
+++ b/lib/logging/Dockerfile
@@ -13,20 +13,14 @@ ARG REPO
 ARG BRANCH
 ARG TAG
 
-RUN git clone "${REPO}"
-RUN ls /logging
+RUN git clone --depth 1 -b "${TAG:-$BRANCH}" "${REPO}" && \
+    ls /logging
 
 WORKDIR /logging/bento_log_service
-
-RUN git fetch && \
-    git checkout "${BRANCH}" && \
-    git checkout tags/${TAG}
 
 RUN ["pip", "install", "-r", "requirements.txt"]
 
 # Run
-WORKDIR /logging/bento_log_service
-
 COPY chord_services.json ./chord_services.json
 
 COPY ./gunicorn_starter.sh .

--- a/lib/notification/Dockerfile
+++ b/lib/notification/Dockerfile
@@ -15,15 +15,11 @@ ARG REPO
 ARG BRANCH
 ARG TAG
 
-RUN git clone "${REPO}"
+RUN git clone --depth 1 -b "${TAG:-$BRANCH}" "${REPO}"
 RUN ls /notification
 
 WORKDIR /notification/bento_notification_service
 
-RUN git fetch && \
-    git checkout "${BRANCH}" && \
-    git checkout tags/${TAG}
-    
 RUN ["pip", "install", "-r", "requirements.txt"]
 
 # Run

--- a/lib/service-registry/Dockerfile
+++ b/lib/service-registry/Dockerfile
@@ -13,17 +13,12 @@ ARG REPO
 ARG BRANCH
 ARG TAG
 
-RUN git clone "${REPO}" && \
+RUN git clone --depth 1 -b "${TAG:-$BRANCH}" "${REPO}" && \
     ls /service-registry
 
 WORKDIR /service-registry/bento_service_registry
 
-RUN git fetch && \
-    git checkout "${BRANCH}" && \
-    git checkout tags/${TAG}
-
 RUN pip install -r requirements.txt
-
 
 # Run
 WORKDIR /service-registry/bento_service_registry

--- a/lib/web/Dockerfile
+++ b/lib/web/Dockerfile
@@ -38,16 +38,11 @@ RUN if [ "$BENTO_WEB_IS_DEBUG" = "true" ] ; then \
         echo "Building Web in Production Mode" ; \
         pwd ; ls -la ; \
         \
-        git clone "${BENTO_WEB_REPO}"; \
+        git clone --depth 1 -b "${BENTO_WEB_TAG:-$BENTO_WEB_BRANCH}" "${BENTO_WEB_REPO}"; \
         pwd ; ls -la ; \
         \
         cd ./bento_web ; \
         pwd ; ls -la ; \
-        \
-        git fetch ; \
-        git checkout "${BENTO_WEB_BRANCH}" ; \
-        git checkout tags/${BENTO_WEB_TAG} ; \
-        git pull ; \
         \
         rm -rf npm-shrinkwrap.json node_modules ; \
         npm cache clean --force ; \
@@ -58,7 +53,7 @@ RUN if [ "$BENTO_WEB_IS_DEBUG" = "true" ] ; then \
 
 # Copy startup scripts
 
-# TODO: parameterize and only copy the 
+# TODO: parameterize and only copy the
 # one that is used
 COPY ./dev_startup.sh /web/dev_startup.sh
 COPY ./startup.sh /web/startup.sh

--- a/lib/wes/Dockerfile
+++ b/lib/wes/Dockerfile
@@ -36,16 +36,10 @@ ARG REPO
 ARG BRANCH
 ARG TAG
 
-RUN git clone "${REPO}"
+RUN git clone --depth 1 -b "${TAG:-$BRANCH}" "${REPO}"
 RUN ls /wes
 
 WORKDIR /wes/bento_wes
-
-RUN git config user.name "docker" && \
-    git config user.email "docker@bento.v2" && \
-    git fetch && \
-    git checkout "${BRANCH}" && \
-    git checkout tags/${TAG}
 
 RUN ["pip", "install", "-r", "requirements.txt"]
 


### PR DESCRIPTION
This PR changes the docker files for the various services in the bento stack so that one can provide a branch name without any tag and get the corresponding container built in production mode. This is useful for testing purposes for example.
Prior to that change, it was not possible to avoid setting a tag version number and that one was overriding the branch name that was set.

Also, this contains a minor improvement where the git repository is only cloned to one level deep in history, which in some cases should reduce the download time.

To test: make sure that the production containers build when a branch name is set and no tag version is used in the .env file