### PR TITLE
Added inline source maps for bento-web

### DIFF
--- a/lib/web/dev_startup.sh
+++ b/lib/web/dev_startup.sh
@@ -10,4 +10,4 @@ nginx -g 'daemon off;' &
 # Removing the ampersand from the following line will prevent webpack output
 # to be streamed to stdout
 echo "-- Running `npm run watch`.. --" &
-npm run watch
+npm run watch -- --devtool inline-source-map


### PR DESCRIPTION
- Now when bento-web is run on development mode, it will have inline source maps